### PR TITLE
feat(): add support for HTTP probe tolerations

### DIFF
--- a/templates/http-deployment.yaml
+++ b/templates/http-deployment.yaml
@@ -37,6 +37,13 @@ spec:
                 operator: In
                 values:
                 - {{ .Values.popArch }}
+      {{- if .Values.http.tolerations.enabled }}
+      tolerations:
+      - effect: {{ Values.http.tolerations.effect }}
+        key: {{ Values.http.tolerations.key }}
+        operator: {{ Values.http.tolerations.operator }}
+        value: {{ Values.http.tolerations.value }}
+      {{- end }}
       imagePullSecrets:
       {{- if .Values.downloadKey }}
       - name: "instana-io"

--- a/values.yaml
+++ b/values.yaml
@@ -117,6 +117,13 @@ http:
       cpu: 300m
       memory: 500Mi
 
+  ## Custom node tolerations assist HTTP probes to run on dedicated edge nodes in certain clusters
+  tolerations:
+    enabled: false
+    effect: NoExecute
+    key: dedicated
+    operator: Equal
+    value: edge
 
 # synthetic-pop-javascript playback engine
 javascript:


### PR DESCRIPTION
- in certain types of clusters only edge types of nodes may be allowed egress to public networks
- feature supports specification of node tolerations to target nodes with specified labels 

e.g. in default values facilitates avoiding execution on nodes other than edge